### PR TITLE
Fixes operations with parameters included in single quotes

### DIFF
--- a/jbehave-netbeans-plugin/src/jbehave/plugin/setpsdictionary/StepsDictionary.java
+++ b/jbehave-netbeans-plugin/src/jbehave/plugin/setpsdictionary/StepsDictionary.java
@@ -209,7 +209,7 @@ public class StepsDictionary
         String[] wordsInOperation = operationInStep.split(" ");
         for (String word : wordsInOperation)
         {
-            if (!word.startsWith("$"))
+            if (!word.startsWith("$") && !word.startsWith("'$"))
             {
                 if (!operationInStory.contains(word))
                 {


### PR DESCRIPTION
Example:
@Given("Given a symbol '$symbol'")
Should be matched by :
Given a symbol '555'